### PR TITLE
Fixes for compilation problems with new gcc-5.2.1. Debian bug 778103. 

### DIFF
--- a/B2BCallManager.cxx
+++ b/B2BCallManager.cxx
@@ -34,8 +34,8 @@ B2BCallManager::B2BCallManager(MediaInterfaceMode mediaInterfaceMode, int defaul
          resip::Headers::Type hType = resip::Headers::getType(headerName.data(), (int)headerName.size());
          if(hType == resip::Headers::UNKNOWN)
          {
-            std::auto_ptr<ExtensionHeader> h(new ExtensionHeader(headerName.c_str()));
-            mReplicatedHeaders.push_back(h);
+            std::unique_ptr<ExtensionHeader> h(new ExtensionHeader(headerName.c_str()));
+            mReplicatedHeaders.push_back(std::move(h));
             InfoLog(<<"Will replicate header '"<<headerName<<"'");
          }
          else
@@ -100,7 +100,7 @@ B2BCallManager::onIncomingParticipant(ParticipantHandle partHandle, const SipMes
    const Uri& reqUri = msg.header(h_RequestLine).uri();
    NameAddr newDest("sip:" + reqUri.user() + '@' + mB2BUANextHop);
    std::multimap<Data,Data> extraHeaders;
-   std::vector<std::auto_ptr<resip::ExtensionHeader> >::const_iterator it = mReplicatedHeaders.begin();
+   std::vector<std::unique_ptr<resip::ExtensionHeader> >::const_iterator it = mReplicatedHeaders.begin();
    for( ; it != mReplicatedHeaders.end(); it++)
    {
       ExtensionHeader& h = **it;

--- a/B2BCallManager.hxx
+++ b/B2BCallManager.hxx
@@ -44,7 +44,7 @@ protected:
    };
 
    Data mB2BUANextHop;
-   std::vector<std::auto_ptr<resip::ExtensionHeader> > mReplicatedHeaders;
+   std::vector<std::unique_ptr<resip::ExtensionHeader> > mReplicatedHeaders;
 
    std::map<ConversationHandle,SharedPtr<B2BCall> > mCallsByConversation;
    std::map<ParticipantHandle,SharedPtr<B2BCall> > mCallsByParticipant;

--- a/README
+++ b/README
@@ -12,7 +12,7 @@ To build this project, note that CPPFLAGS are necessary:
 
 $ git clone $REPOSITORY
 $ cd reConServer
-$ ./configure CPPFLAGS="-I/usr/include/sipxtapi -DDEFAULT_BRIDGE_MAX_IN_OUTPUTS=10 -D__pingtel_on_posix__ -D_linux -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DRESIP_TOOLCHAIN_GNU -DRESIP_OSTYPE_LINUX -DRESIP_ARCH_X86_64 -DHAVE_sockaddr_in_len -DUSE_CARES -DUSE_SSL -DUSE_IPV6 -DHAVE_EPOLL"
+$ ./configure CPPFLAGS="-I/usr/include/sipxtapi -DDEFAULT_BRIDGE_MAX_IN_OUTPUTS=10 -D__pingtel_on_posix__ -D_linux -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DRESIP_TOOLCHAIN_GNU -DRESIP_OSTYPE_LINUX -DRESIP_ARCH_X86_64 -DHAVE_sockaddr_in_len -DUSE_CARES -DUSE_SSL -DUSE_IPV6 -DHAVE_EPOLL -std=c++11"
 $ autoreconf --install
 $ make
 

--- a/build/travis/configure
+++ b/build/travis/configure
@@ -4,5 +4,5 @@ set -e
 
 ./configure \
   CPPFLAGS="-I/usr/include/sipxtapi -D__pingtel_on_posix__ -D_linux_ -D_REENTRANT -D_FILE_OFFS -DDEFAULT_BRIDGE_MAX_IN_OUTPUTS=20 -DUSE_SSL" \
-  CXXFLAGS="-fpermissive"
+  CXXFLAGS="-fpermissive -std=c++11"
 

--- a/reConServer.cxx
+++ b/reConServer.cxx
@@ -1177,7 +1177,7 @@ ReConServerProcess::main (int argc, char** argv)
    // Create ConverationManager and UserAgent
    //////////////////////////////////////////////////////////////////////////////
    {
-      std::auto_ptr<MyConversationManager> myConversationManager;
+      std::unique_ptr<MyConversationManager> myConversationManager;
       switch(application)
       {
          case ReConServerConfig::None:


### PR DESCRIPTION
Fixes for compilation problems with new gcc-5.2.1 found 
at debian-sid. This gets rid of auto_ptr and replaces it with unique_ptr.
In order to unique_ptr to work right, a new CXXFLAG has been added
to configure script, it adds -std=c++11 to flags. This flag is all
right also for gcc-4.9 found from earlier debian versions.
For more information see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=778103 at BTS.
